### PR TITLE
Add dark mode and enhance practice test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# PawlsByte GitHub Pages
+
+This repository hosts multiple HTML files and the `americlean-ascs-study` training site. To view the ASCS study materials on GitHub Pages, visit:
+
+```
+https://pawlsbyte.github.io/americlean-ascs-study/
+```
+
+If the pages do not appear, ensure the `work` branch has been merged into `main` and GitHub Pages is configured to build from the `main` branch.
+The `americlean-ascs-study` folder contains all HTML, CSS, and JavaScript for the online study portal.
+

--- a/americlean-ascs-study/css/styles.css
+++ b/americlean-ascs-study/css/styles.css
@@ -48,3 +48,21 @@ ul {
 .dark-mode header {
   background: #1f1f1f;
 }
+
+button[data-index] {
+  margin: 0.25rem 0;
+  padding: 0.5rem 1rem;
+  border: none;
+  background: #e2e8f0;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button[data-index]:hover {
+  background: #cbd5e1;
+}
+
+#progress {
+  margin-bottom: 1rem;
+  font-weight: bold;
+}

--- a/americlean-ascs-study/data/practice-questions.json
+++ b/americlean-ascs-study/data/practice-questions.json
@@ -1,0 +1,57 @@
+[
+  {
+    "question": "What does a negative air machine accomplish during duct cleaning?",
+    "options": [
+      "Increases airflow to occupied spaces",
+      "Creates pressure to contain contaminants",
+      "Adds moisture for debris removal",
+      "Eliminates the need for protective equipment"
+    ],
+    "answer": 1,
+    "hint": "Think about how we keep dust from escaping the work area."
+  },
+  {
+    "question": "Which document outlines the industry standard for HVAC cleaning?",
+    "options": [
+      "ASHRAE Handbook",
+      "ACR, The NADCA Standard",
+      "EPA Clean Air Act",
+      "International Mechanical Code"
+    ],
+    "answer": 1,
+    "hint": "It is published by NADCA and referenced throughout training materials."
+  },
+  {
+    "question": "Before starting any cleaning procedure, what should be done first to ensure system safety?",
+    "options": [
+      "Open supply registers",
+      "Secure the area with caution tape",
+      "Shut down the HVAC system",
+      "Spray disinfectant into returns"
+    ],
+    "answer": 2,
+    "hint": "No mechanical components should be running while you work."
+  },
+  {
+    "question": "What is the recommended method for verifying cleanliness after duct cleaning?",
+    "options": [
+      "Visual inspection",
+      "Chemical swab testing",
+      "Airflow measurement",
+      "Customer testimonial"
+    ],
+    "answer": 0,
+    "hint": "Look inside the ducts to ensure debris removal."
+  },
+  {
+    "question": "HEPA filters capture particles down to what size?",
+    "options": [
+      "1 micron",
+      "0.3 microns",
+      "5 microns",
+      "0.03 microns"
+    ],
+    "answer": 1,
+    "hint": "It's the standard rating for high-efficiency filters."
+  }
+]

--- a/americlean-ascs-study/flashcards.html
+++ b/americlean-ascs-study/flashcards.html
@@ -5,6 +5,7 @@
   <title>Flashcards – ASCS Study</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="css/styles.css" />
+  <script defer src="js/app.js"></script>
   <script defer src="js/flashcards.js"></script>
 </head>
 <body>
@@ -12,6 +13,7 @@
     <img src="images/americlean-logo.png" alt="Logo" id="logo" />
     <h1>Flashcards</h1>
     <a href="index.html" class="start-btn">Back to Home</a>
+    <button id="darkModeToggle">🌓</button>
   </header>
   <main>
     <section id="flashcard-container" style="display:flex; flex-wrap:wrap; gap:1rem;"></section>

--- a/americlean-ascs-study/guide.html
+++ b/americlean-ascs-study/guide.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ASCS Study Guide</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="css/styles.css">
+  <script defer src="js/app.js"></script>
+</head>
+<body>
+  <header>
+    <img src="images/americlean-logo.png" alt="Logo" id="logo" />
+    <h1>ASCS Study Guide</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="flashcards.html">Flashcards</a>
+      <a href="quiz.html">Practice Quiz</a>
+      <a href="practice-test.html">Practice Test</a>
+    </nav>
+    <button id="darkModeToggle">🌓</button>
+  </header>
+  <main>
+    <section>
+      <h2>Course Overview</h2>
+      <p>This guide condenses key topics for the NADCA Air Systems Cleaning Specialist (ASCS) exam. It summarizes essential concepts and links to the interactive resources on this site.</p>
+    </section>
+    <section>
+      <h3>1. HVAC Fundamentals</h3>
+      <p>Understand airflow, system components, and pressure relationships. Review duct types, plenums, and filtration methods.</p>
+    </section>
+    <section>
+      <h3>2. Cleaning Techniques</h3>
+      <p>Study contact cleaning vs. source removal, negative air machines, and proper containment. Emphasize steps to prevent cross contamination.</p>
+    </section>
+    <section>
+      <h3>3. NADCA Standards</h3>
+      <p>Familiarize yourself with ACR, The NADCA Standard. Know documentation requirements and inspection guidelines.</p>
+    </section>
+    <section>
+      <h3>4. Safety &amp; Regulations</h3>
+      <p>Review PPE usage, ladder safety, and respirator types. Understand EPA, OSHA, and local codes related to HVAC cleaning.</p>
+    </section>
+    <section>
+      <h3>5. Exam Tips</h3>
+      <ul>
+        <li>Use the <a href="flashcards.html">flashcards</a> to memorize terms.</li>
+        <li>Try the <a href="quiz.html">practice quiz</a> for instant feedback.</li>
+        <li>Simulate exam conditions with the <a href="practice-test.html">practice test</a>.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/americlean-ascs-study/index.html
+++ b/americlean-ascs-study/index.html
@@ -14,6 +14,10 @@
     <nav>
       <a href="index.html">Home</a>
       <a href="modules/hvac-basics.html">Study Module</a>
+      <a href="flashcards.html">Flashcards</a>
+      <a href="quiz.html">Quiz</a>
+      <a href="practice-test.html">Practice Test</a>
+      <a href="guide.html">Study Guide</a>
     </nav>
     <button id="darkModeToggle">🌓</button>
   </header>

--- a/americlean-ascs-study/js/practice-test.js
+++ b/americlean-ascs-study/js/practice-test.js
@@ -1,0 +1,51 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const container = document.getElementById("test-container");
+  const resultEl = document.getElementById("test-result");
+  const progressEl = document.getElementById("progress");
+  let index = 0;
+  let score = 0;
+
+  fetch("../data/practice-questions.json")
+    .then(res => res.json())
+    .then(data => {
+      // simple shuffle for question order
+      data.sort(() => Math.random() - 0.5);
+      function showQuestion() {
+        const q = data[index];
+        progressEl.textContent = `Question ${index + 1} of ${data.length}`;
+        container.innerHTML = `
+          <h3>${q.question}</h3>
+          <ul>
+            ${q.options.map((opt,i)=>`<li><button data-index="${i}">${opt}</button></li>`).join('')}
+          </ul>
+          <button id="hint-btn" style="margin-top:1rem;">Hint</button>
+          <p id="hint" style="display:none;margin-top:0.5rem;background:#f1f1f1;padding:0.5rem;border-radius:4px;"></p>
+        `;
+
+        document.getElementById("hint-btn").addEventListener("click", () => {
+          const hint = document.getElementById("hint");
+          hint.textContent = q.hint;
+          hint.style.display = "block";
+        });
+
+        container.querySelectorAll("button[data-index]").forEach(btn => {
+          btn.addEventListener("click", () => {
+            const chosen = parseInt(btn.dataset.index);
+            if (chosen === q.answer) {
+              score++;
+            }
+            index++;
+            if (index < data.length) {
+              showQuestion();
+            } else {
+              container.innerHTML = "";
+              progressEl.textContent = "";
+              resultEl.textContent = `Test Complete! Score: ${score}/${data.length}`;
+            }
+          });
+        });
+      }
+
+      showQuestion();
+    });
+});

--- a/americlean-ascs-study/modules/hvac-basics.html
+++ b/americlean-ascs-study/modules/hvac-basics.html
@@ -11,6 +11,7 @@
   <header>
     <img src="../images/americlean-logo.png" alt="Logo" id="logo" />
     <h1>HVAC System Basics</h1>
+    <button id="darkModeToggle">🌓</button>
   </header>
   <main>
     <section>

--- a/americlean-ascs-study/practice-test.html
+++ b/americlean-ascs-study/practice-test.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Practice Test – ASCS</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="css/styles.css">
+  <script defer src="js/app.js"></script>
+  <script defer src="js/practice-test.js"></script>
+</head>
+<body>
+  <header>
+    <img src="images/americlean-logo.png" alt="Logo" id="logo" />
+    <h1>Practice Test</h1>
+    <a href="index.html" class="start-btn">Back to Home</a>
+    <button id="darkModeToggle">🌓</button>
+  </header>
+  <main>
+    <p id="progress"></p>
+    <section id="test-container"></section>
+    <section id="test-result" style="margin-top:2rem;font-weight:bold;"></section>
+  </main>
+</body>
+</html>

--- a/americlean-ascs-study/quiz.html
+++ b/americlean-ascs-study/quiz.html
@@ -5,6 +5,7 @@
   <title>Practice Quiz – ASCS Study</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="css/styles.css" />
+  <script defer src="js/app.js"></script>
   <script defer src="js/quiz.js"></script>
 </head>
 <body>
@@ -12,6 +13,7 @@
     <img src="images/americlean-logo.png" alt="Logo" id="logo" />
     <h1>Practice Quiz</h1>
     <a href="index.html" class="start-btn">Back to Home</a>
+    <button id="darkModeToggle">🌓</button>
   </header>
   <main>
     <section id="quiz"></section>


### PR DESCRIPTION
## Summary
- add dark mode toggle and script to all study pages
- expand practice test question bank and randomize question order
- show progress indicator during test

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6887d731524c832780a34134a5739225